### PR TITLE
fix json number parsing, issue #9

### DIFF
--- a/run_test.rb
+++ b/run_test.rb
@@ -6,18 +6,17 @@
 if __FILE__ == $0
   repository, dir = 'https://github.com/mruby/mruby.git', 'tmp/mruby'
   build_args = ARGV
-
   Dir.mkdir 'tmp'  unless File.exist?('tmp')
   unless File.exist?(dir)
     system "git clone #{repository} #{dir}"
   end
-
   exit system(%Q[cd #{dir}; MRUBY_CONFIG=#{File.expand_path __FILE__} ruby minirake #{build_args.join(' ')}])
 end
 
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-
+  
+  enable_test
   conf.gem File.expand_path(File.dirname(__FILE__))
 end

--- a/src/json.c
+++ b/src/json.c
@@ -34,7 +34,7 @@ static int json_whitespace_p(char ch);
 
 static int json_parse_array(struct json_parser *, mrb_value *);
 static int json_parse_object(struct json_parser *, mrb_value *);
-static int json_parse_number2(struct json_parser *, int, mrb_value *, int, int);
+static int json_parse_number2(struct json_parser *, int, mrb_value *, double, int);
 static int json_parse_string(struct json_parser *, mrb_value *);
 static int json_parse_value(struct json_parser *, mrb_value *);
 
@@ -310,8 +310,8 @@ json_parse_number(struct json_parser *parser, int ch, mrb_value *result)
       }
     } else if (ch == '.' || ch == 'e' || ch == 'E') {
       if( use_float > 0)
-        mrb_raise(mrb, E_JSON_PARSER_ERROR, "parsing of large floats is not implemented yet");
-      return json_parse_number2(parser, ch, result, num, sign);
+        return json_parse_number2(parser, ch, result, num_float, sign);
+      return json_parse_number2(parser, ch, result, num, sign); //auto convert
     } else if (json_delimiter_p(ch)) {
       json_ungetc(parser);
       break;
@@ -330,7 +330,7 @@ json_parse_number(struct json_parser *parser, int ch, mrb_value *result)
 }
 
 static int
-json_parse_number2(struct json_parser *parser, int ch, mrb_value *result, int num, int sign)
+json_parse_number2(struct json_parser *parser, int ch, mrb_value *result, double num, int sign)
 {
   mrb_state *mrb = parser->mrb;
   double d;
@@ -341,7 +341,7 @@ json_parse_number2(struct json_parser *parser, int ch, mrb_value *result, int nu
    * "-"? ("0" | [1-9] digit* ) ("." digit+ )? ([eE][-+] digit+)?
    * state:                      000 111111     22223333 444444
    */
-  i = snprintf(buf, sizeof(buf), "%s%d%c",
+  i = snprintf(buf, sizeof(buf), "%s%f%c",
       (num == 0 && sign < 0) ? "-" : "",
       num, ch);
   if (ch == '.')

--- a/test/json.rb
+++ b/test/json.rb
@@ -102,6 +102,15 @@ assert('JSON.parse: text from RFC4726') do
   assert_equal hash, JSON.parse(JSON.generate(hash))
 end
 
+assert('JSON.parse: Number that is bigger than MRB_INT_MAX') do 
+
+  assert_equal 2147483647, JSON.load("2147483647")
+  assert_equal 2147483648, JSON.load("2147483648")
+  assert_equal 9223372036854775807, JSON.load("9223372036854775807")   #fails if #define MRB_INT64
+  assert_equal 0, JSON.load("9223372036854775808") - 9223372036854775808.0
+   #assert_equal 9223372036854775808.123, JSON.load("9223372036854775808.123")
+end
+
 assert('JSON::ParserError') do
   assert_raise(JSON::ParserError) do
     JSON.parse "[xxx]"
@@ -123,4 +132,5 @@ assert('#to_json') do
   assert_equal '"str"',     "str".to_json
   assert_equal '["one",2]', [ "one", 2 ].to_json
   assert_equal '{"a":1}',   { "a" => 1 }.to_json
+  assert_equal '15017616976', 15017616976.to_json
 end

--- a/test/json.rb
+++ b/test/json.rb
@@ -102,13 +102,12 @@ assert('JSON.parse: text from RFC4726') do
   assert_equal hash, JSON.parse(JSON.generate(hash))
 end
 
-assert('JSON.parse: Number that is bigger than MRB_INT_MAX') do 
-
+assert('JSON.parse: parsing a Number that is bigger than MRB_INT_MAX') do 
   assert_equal 2147483647, JSON.load("2147483647")
   assert_equal 2147483648, JSON.load("2147483648")
   assert_equal 9223372036854775807, JSON.load("9223372036854775807")   #fails if #define MRB_INT64
-  assert_equal 0, JSON.load("9223372036854775808") - 9223372036854775808.0
-   #assert_equal 9223372036854775808.123, JSON.load("9223372036854775808.123")
+  assert_equal 9223372036854775808.to_s, JSON.load("9223372036854775808").to_s
+  assert_equal 9223372036854775808.123.to_s, JSON.load("9223372036854775808.123").to_s 
 end
 
 assert('JSON::ParserError') do


### PR DESCRIPTION
note: there seems to be a bug in mruby too, if you enable tests and you switch from `#define MRB_INT64` or vice versa you may see the tests failing. if you then comment them out, complete the compilation and run them again it works. 