### PR TITLE
Use `to_h` instead

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,5 +2,7 @@ MRuby::Gem::Specification.new('mruby-iijson') do |spec|
   spec.license = 'MIT'
   spec.author  = 'Internet Initiative Japan Inc.'
 
-  spec.add_dependency "mruby-sprintf", :core => "mruby-sprintf"
+  add_dependency 'mruby-hash-ext', core: 'mruby-hash-ext'
+  add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
+  add_dependency "mruby-sprintf", core: "mruby-sprintf"
 end

--- a/mrblib/json.rb
+++ b/mrblib/json.rb
@@ -16,10 +16,10 @@ module JSON
   end
 
   def self.generate(obj, options=nil, state=nil)
-    options = (options || {}).to_hash unless options.is_a? Hash
+    options = (options || {}).to_h unless options.is_a? Hash
     options[:pretty_print] ||= false
     options[:indent_with] ||= 2
-    state = (state || {}).to_hash unless state.is_a? Hash
+    state = (state || {}).to_h unless state.is_a? Hash
     state[:max_nesting] ||= 100
     state[:nesting] = 0
     self.generate0(obj, options, state)


### PR DESCRIPTION
Since implicit conversion methods are removed in 2.0